### PR TITLE
build fix - rename subfolder

### DIFF
--- a/InvisibilityCloak.py
+++ b/InvisibilityCloak.py
@@ -199,8 +199,10 @@ def replaceGUIDAndToolName(theDirectory, theName):
 
 	origWorkingDir = os.getcwd()
 	os.chdir(theDirectory)
+	if os.path.exists(currentToolName):
+		os.rename(currentToolName, theName)
 	if os.path.isfile(currentToolName) or os.path.exists(theDirectory + "\\" + currentToolName):
-                os.rename(currentToolName, theName)
+		os.rename(currentToolName, theName)
 	os.chdir(origWorkingDir)
 
 	print("")


### PR DESCRIPTION
Before the fix the primary subfolder doesnt get renamed which causes the build to fail.

```
py InvisibilityCloak\InvisibilityCloak.py -d Seatbelt -n TestBelt -m base64
```

build:

```
msbuild /t:Rebuild -p:Configuration=Release;TargetFrameworkVersion=v4.0
```

output:
```
..snip...

ValidateSolutionConfiguration:
  Building solution configuration "Release|Any CPU".
Z:\Seatbelt\TestBelt.sln.metaproj : error MSB3202: The project file "Z:\Seatbelt\TestBelt\TestBelt.csproj" was not found. [Z:\Seatbelt\TestBelt.sln]
Done Building Project "Z:\Seatbelt\TestBelt.sln" (Rebuild target(s)) -- FAILED.

Build FAILED.
```

After the fix it compiles just fine.